### PR TITLE
OSX ARM Migration + pyproject.toml fix

### DIFF
--- a/patches/0001-fix-pyproject-toml.patch
+++ b/patches/0001-fix-pyproject-toml.patch
@@ -1,0 +1,42 @@
+From 6e2a22d5656ae3f11496b9c59e2e4b4376723e32 Mon Sep 17 00:00:00 2001
+From: Max Schelker <max.schelker@nostos-genomics.com>
+Date: Thu, 29 Jun 2023 15:04:15 +0200
+Subject: [PATCH 1/2] fix pyproject.yaml `project` must contain ['name']
+ properties error #397
+
+---
+ pyproject.toml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 350ce22e..52a42484 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,4 +1,5 @@
+ [project]
++name = "scikit-allel"
+ requires-python = ">=3.6"
+ 
+ [build-system]
+
+From 1d35fed62b64decb19c42870a3f1de5cc3898f14 Mon Sep 17 00:00:00 2001
+From: Max Schelker <max.schelker@nostos-genomics.com>
+Date: Thu, 29 Jun 2023 15:11:19 +0200
+Subject: [PATCH 2/2] also fix missing `version` property
+
+---
+ pyproject.toml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 52a42484..31c8d3ea 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,6 +1,7 @@
+ [project]
+ name = "scikit-allel"
+ requires-python = ">=3.6"
++dynamic = ["version", "description"]
+ 
+ [build-system]
+ # Minimum requirements for the build system to execute.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,8 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - patches/0001-fix-pyproject-toml.patch
 
 build:
   number: 0


### PR DESCRIPTION
The auto migrator pipeline fails due to this issue: https://github.com/cggh/scikit-allel/issues/397
This was fixed in PR https://github.com/cggh/scikit-allel/pull/398 but not merged so far, thus I added it as patch